### PR TITLE
Update plugin release to v2.1.2

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $plugin->requires = 2012120301;
 $plugin->component = 'local_obu_metalinking';
 $plugin->maturity = MATURITY_STABLE;
 
-$plugin->release = 'v2.1.1';
+$plugin->release = 'v2.1.2';
 $plugin->dependencies = array(
     'enrol_meta' => 2022112800,
     'local_obu_group_manager' => 2024072902,


### PR DESCRIPTION
Incremented the plugin release version from v2.1.1 to v2.1.2. This change ensures proper version tracking and indicates the latest stable release of the plugin. No other functional changes were made.